### PR TITLE
Add devcontainer and extensions config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,5 +9,5 @@
 
 	// "forwardPorts": [],
 
-	"postCreateCommand": "python3 -m pip install -r requirements.txt"
+	"postCreateCommand": "python3 -m pip install -r requirements.txt && pre-commit install && dbt deps"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+	"name": "Python 3",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.10-bookworm",
+	"features": {
+		"ghcr.io/eitsupi/devcontainer-features/go-task:1": {
+			"version": "latest"
+		}
+	},
+
+	// "forwardPorts": [],
+
+	"postCreateCommand": "python3 -m pip install -r requirements.txt"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,22 @@
+{
+    "recommendations": [
+        "github.codespaces",
+        "gitpod.gitpod-desktop",
+        "ms-vscode-remote.vscode-remote-extensionpack",
+        "evidence.evidence-vscode",
+        "GitHub.vscode-pull-request-github",
+        "cschleiden.vscode-github-actions",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.black-formatter",
+        "ms-python.isort",
+        "charliermarsh.ruff",
+        "redhat.vscode-yaml",
+        "task.vscode-task",
+        "samuelcolvin.jinjahtml",
+        "bungcip.better-toml",
+        "tamasfe.even-better-toml",
+        "mechatroner.rainbow-csv",
+        "bastienboutonnet.vscode-dbt"
+    ]
+}


### PR DESCRIPTION
One portion of feedback from @archiewood is that we need to, yknow, actually configure the devcontainers if we present that as an option 😅 this adds some baseline config for that and recommended vscode extensions.

Closes #11 