### PR TITLE
Add issues summary page

### DIFF
--- a/reports/pages/issues.md
+++ b/reports/pages/issues.md
@@ -1,5 +1,114 @@
 ---
 title: Analyzing Issues
+sources:
+  - issues.sql
 ---
 
-Coming soon! You could contribute this page!
+In the last <Value data={issue_summary} column="last_hours"/> hours there have been <b><Value data={issue_summary} column="issues"/></b> events across <Value data={issue_summary} column="repo_count"/> repositories! This has involved <Value data={issue_summary} column="actor_count"/> contributors opening and closing issues, <Value data={issue_summary} column="opened_events"/> and <Value data={issue_summary} column="closed_events"/> respectively.
+
+
+
+
+<!-- Coming soon! You could contribute this page! -->
+<BigValue 
+    data={issue_count} 
+    sparkline='date'
+    comparison='count_day_prior' 
+    comparisonTitle="Compared to Yesterday"
+    value='issues' 
+    maxWidth='10em'
+/>
+
+<BigValue 
+    data={issue_summary} 
+    value='repo_count' 
+    maxWidth='10em'
+/>
+
+<BigValue 
+    data={issue_summary} 
+    value='actor_count' 
+    maxWidth='10em'
+/>
+
+
+<BarChart
+  data={issue_count_hour}
+  x="hour_of_day"
+  y="issues"
+  series="issue_action"
+  title = "Issues by hour"
+/>
+
+
+
+
+
+<DataTable
+  search="true"
+  data="{issues_per_repo}"
+  title="Issues per Repository"
+  link="issue_repo_url"
+  >
+  <Column id= "repo_name"/>
+  <Column id= "actors"/>
+  <Column id= "closed_events"/>
+  <Column id= "closed_events"/>
+  <Column id= "number_of_issues"/>
+</DataTable>
+
+## Issue Sample
+```sql issuesraw
+select * from ${issues} limit 100
+```
+<Details title="Definitions">
+
+```sql issue_summary
+select 
+  count(1)::INT as issues,
+  count(distinct actor_id)::INT as actor_count,
+  count(distinct repo_id)::INT as repo_count,
+  date_diff('hour', min(event_created_at)::TIMESTAMPTZ, now()::TIMESTAMPTZ) as last_hours,
+  count(1) filter(where issue_action = 'opened')::INT as opened_events,
+  count(1) filter(where issue_action = 'closed')::INT as closed_events,
+  from ${issues}
+
+```
+
+```sql issue_count
+  select count(1) as issues,
+    count(1) - count(1) filter(where issue_created_at < now() AT TIME ZONE 'UTC' - interval '1 Day') as count_day_prior,
+  from ${issues} 
+  group by all
+```
+
+```sql issue_count_hour
+  select 
+    date_trunc('hour', event_created_at) as hour_of_day,
+    case 
+      when issue_action = 'opened' then 'Opened'
+      when issue_action = 'closed' then 'Closed'
+      else 'Unknown'
+      end as issue_action,
+    count(1) as issues,
+  from ${issues} 
+  group by all
+  order by all
+
+```
+
+```sql issues_per_repo
+select
+  repo_name,
+  issue_repo_url,
+  count(distinct issue_id) as number_of_issues,
+  count(distinct actor_id) as actors,
+  count(1) filter(where issue_action = 'opened') as opened_events,
+  count(1) filter(where issue_action = 'closed') as closed_events,
+from ${issues}
+group by all
+having number_of_issues > 2
+order by 2 desc
+```
+
+</Details>

--- a/reports/pages/issues.md
+++ b/reports/pages/issues.md
@@ -4,7 +4,7 @@ sources:
   - issues.sql
 ---
 
-In the last <Value data={issue_summary} column="last_hours"/> hours there have been <b><Value data={issue_summary} column="issues"/></b> events across <Value data={issue_summary} column="repo_count"/> repositories! This has involved <Value data={issue_summary} column="actor_count"/> contributors opening and closing issues, <Value data={issue_summary} column="opened_events"/> and <Value data={issue_summary} column="closed_events"/> respectively.
+In the last <Value data={issue_summary} column="last_hours"/> hours there have been <b><Value data={issue_summary} column="issues" fmt="num0 auto"/></b> events across <Value data={issue_summary} column="repo_count" fmt="num0 auto"/> repositories! This has involved <Value data={issue_summary} column="actor_count" fmt="num0 auto"/> contributors opening and closing issues, <Value data={issue_summary} column="opened_events" fmt="num0 auto"/> and <Value data={issue_summary} column="closed_events" fmt="num0 auto"/> respectively.
 
 <b><Value data={top_actor} /></b> was the top contributor with <b><Value data={top_actor_repo} column="repo_events"/></b> issues added to <b><Value data={top_actor_repo} column="repo_name"/></b> repository!
 

--- a/reports/pages/issues.md
+++ b/reports/pages/issues.md
@@ -7,8 +7,6 @@ sources:
 In the last <Value data={issue_summary} column="last_hours"/> hours there have been <b><Value data={issue_summary} column="issues"/></b> events across <Value data={issue_summary} column="repo_count"/> repositories! This has involved <Value data={issue_summary} column="actor_count"/> contributors opening and closing issues, <Value data={issue_summary} column="opened_events"/> and <Value data={issue_summary} column="closed_events"/> respectively.
 
 
-
-
 <!-- Coming soon! You could contribute this page! -->
 <BigValue 
     data={issue_count} 
@@ -32,22 +30,22 @@ In the last <Value data={issue_summary} column="last_hours"/> hours there have b
 />
 
 
+### Issues by hour
 <BarChart
   data={issue_count_hour}
   x="hour_of_day"
   y="issues"
   series="issue_action"
-  title = "Issues by hour"
 />
 
 
 
 
 
+### Issues summary by repo
 <DataTable
   search="true"
   data="{issues_per_repo}"
-  title="Issues per Repository"
   link="issue_repo_url"
   >
   <Column id= "repo_name"/>

--- a/reports/pages/issues.md
+++ b/reports/pages/issues.md
@@ -6,8 +6,10 @@ sources:
 
 In the last <Value data={issue_summary} column="last_hours"/> hours there have been <b><Value data={issue_summary} column="issues"/></b> events across <Value data={issue_summary} column="repo_count"/> repositories! This has involved <Value data={issue_summary} column="actor_count"/> contributors opening and closing issues, <Value data={issue_summary} column="opened_events"/> and <Value data={issue_summary} column="closed_events"/> respectively.
 
-<b><Value data={query_name} /></b> was the top actor 
+<b><Value data={top_actor} /></b> was the top contributor with <b><Value data={top_actor_repo} column="repo_events"/></b> issues added to <b><Value data={top_actor_repo} column="repo_name"/></b> repository!
 
+<br>
+<br>
 
 <!-- Coming soon! You could contribute this page! -->
 <BigValue 
@@ -60,7 +62,13 @@ In the last <Value data={issue_summary} column="last_hours"/> hours there have b
 ## Issue Sample
 ```sql issuesraw
 select * from ${issues} limit 100
+
 ```
+
+<br>
+
+_The longest content issue in the data set reads:_ <Value data={issue_content_len} />
+<br>
 <Details title="Definitions">
 
 ```sql issue_summary
@@ -81,7 +89,8 @@ from ${issues}
     count(1) as actor_events,
   from ${issues}
   group by all
-  order by actor_login
+  having actor_events>1
+  order by actor_login desc
   limit 1
 ```
 
@@ -94,6 +103,17 @@ from ${issues}
   limit 1
 ```
 
+
+```sql issue_content_len
+  select 
+    left(issue_body, 400) as content_summary,
+    issue_body,
+    length(issue_body) as issue_body_len,
+  from ${issues} 
+  group by all
+  order by issue_body_len desc
+  limit 1
+```
 
 ```sql issue_count
   select count(1) as issues,

--- a/reports/pages/issues.md
+++ b/reports/pages/issues.md
@@ -128,7 +128,7 @@ from ${issues}
     case 
       when issue_action = 'opened' then 'Opened'
       when issue_action = 'closed' then 'Closed'
-      else 'Unknown'
+      else issue_action
       end as issue_action,
     count(1) as issues,
   from ${issues} 

--- a/reports/pages/issues.md
+++ b/reports/pages/issues.md
@@ -6,6 +6,8 @@ sources:
 
 In the last <Value data={issue_summary} column="last_hours"/> hours there have been <b><Value data={issue_summary} column="issues"/></b> events across <Value data={issue_summary} column="repo_count"/> repositories! This has involved <Value data={issue_summary} column="actor_count"/> contributors opening and closing issues, <Value data={issue_summary} column="opened_events"/> and <Value data={issue_summary} column="closed_events"/> respectively.
 
+<b><Value data={query_name} /></b> was the top actor 
+
 
 <!-- Coming soon! You could contribute this page! -->
 <BigValue 
@@ -69,9 +71,29 @@ select
   date_diff('hour', min(event_created_at)::TIMESTAMPTZ, now()::TIMESTAMPTZ) as last_hours,
   count(1) filter(where issue_action = 'opened')::INT as opened_events,
   count(1) filter(where issue_action = 'closed')::INT as closed_events,
-  from ${issues}
+from ${issues}
 
 ```
+<!-- Actor summary -->
+```sql top_actor
+  select 
+    actor_login, 
+    count(1) as actor_events,
+  from ${issues}
+  group by all
+  order by actor_login
+  limit 1
+```
+
+```sql top_actor_repo
+  select repo_name,
+    count(1) as repo_events
+  from ${issues}
+  where actor_login = (select actor_login from ${top_actor})
+  group by all
+  limit 1
+```
+
 
 ```sql issue_count
   select count(1) as issues,

--- a/reports/sources/issues.sql
+++ b/reports/sources/issues.sql
@@ -1,0 +1,1 @@
+select * from issue_events

--- a/reports/sources/issues.sql
+++ b/reports/sources/issues.sql
@@ -1,1 +1,1 @@
-select * from issue_events
+select * from octocatalog.issue_events


### PR DESCRIPTION
A few issues with this but cannot seem to nut it out atm.

- ~some headline figures are showing 1 or 2 decimal points (been 10,946**.0** events)~
- when clicking the repo name it navigates to the URL which is the API json reference (https://api.github.com/repos/zkxjzmswkwl/Carnival)

## Screenshots
<img width="1300" alt="image" src="https://github.com/gwenwindflower/octocatalog/assets/8232214/8503045b-51a5-41a2-a5c9-734d2db1136d">
<img width="573" alt="image" src="https://github.com/gwenwindflower/octocatalog/assets/8232214/92d1d7b5-c6b0-4208-aeb1-93e9f88695c1">
