### PR TITLE
Use ocotocatalog.[foo] not main.[foo] in Evidence sources

### DIFF
--- a/reports/sources/quack/issues.sql
+++ b/reports/sources/quack/issues.sql
@@ -1,1 +1,1 @@
-select * from main.issue_events;
+select * from octocatalog.issue_events;

--- a/reports/sources/quack/pull_requests.sql
+++ b/reports/sources/quack/pull_requests.sql
@@ -1,1 +1,1 @@
-select * from main.pull_request_events limit 20000;
+select * from octocatalog.pull_request_events limit 20000;


### PR DESCRIPTION
Fast follow on the previous, deploy is going great but it can't find the right db/schema situation. I think this will get it working.